### PR TITLE
fix hyrule circuit spelling

### DIFF
--- a/src/lib/screens/intro.rs
+++ b/src/lib/screens/intro.rs
@@ -176,7 +176,7 @@ lazy_static! {
             files: vec![load_reference_hash!("intro/ice_ice_outpost.jpg")],
         },
         IntroReference {
-            name: "Hyrule Circult",
+            name: "Hyrule Circuit",
             files: vec![load_reference_hash!("intro/hyrule_circuit.jpg")],
         },
         IntroReference {


### PR DESCRIPTION
this spelling was copied over from the old analyser, but it was fixed [here](https://github.com/ferocia/kartalytics/commit/10cbdaf5aea7835de797e9455a1b6a442c4f7ffb), so we also need to ensure the rust analyser sends circuit and not circult.